### PR TITLE
Implement outputting .vcf from `kbo map`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4", features = ["derive"]}
 kbo = "0.4.1"
 log = "0.4.20"
 needletail = { version = "0.6.0", default-features = false, features = ["flate2"] }
+noodles-vcf = "0.49"
 rayon = "1"
 sbwt = "0.3.4"
 stderrlog = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 ## core
 clap = { version = "4", features = ["derive"]}
+chrono = "0.4.40"
 kbo = "0.4.1"
 log = "0.4.20"
 needletail = { version = "0.6.0", default-features = false, features = ["flate2"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,6 +126,10 @@ pub enum Commands {
         #[arg(short = 'r', long = "reference", required = true, help_heading = "Input")]
         ref_file: String,
 
+        // Output format
+        #[arg(short = 'f', long = "format", default_value = "aln", help_heading = "Output")]
+        out_format: String,
+
         // Parameters
         // // Upper bound for random match probability
         #[arg(long = "max-error-prob", default_value_t = 0.0000001, help_heading = "Algorithm")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,7 +128,7 @@ pub enum Commands {
         ref_file: String,
 
         // Output format
-        #[arg(short = 'f', long = "format", default_value = "aln", help_heading = "Output")]
+        #[arg(short = 'f', long = "format", default_value = "aln", help_heading = "Output", help = "Output format (aln or vcf)")]
         out_format: String,
 
         // Parameters

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,9 +126,6 @@ pub enum Commands {
         // // Reference file
         #[arg(short = 'r', long = "reference", required = true, help_heading = "Input")]
         ref_file: String,
-        // // Do not concatenate contigs in reference
-        #[arg(long = "detailed", help_heading = "Input", default_value_t = false)]
-        detailed: bool,
 
         // Output format
         #[arg(short = 'f', long = "format", default_value = "aln", help_heading = "Output")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,9 +122,13 @@ pub enum Commands {
         #[arg(group = "input", required = true)]
         query_files: Vec<String>,
 
-        // Reference fasta
+        // Input options
+        // // Reference file
         #[arg(short = 'r', long = "reference", required = true, help_heading = "Input")]
         ref_file: String,
+        // // Do not concatenate contigs in reference
+        #[arg(long = "detailed", help_heading = "Input", default_value_t = false)]
+        detailed: bool,
 
         // Output format
         #[arg(short = 'f', long = "format", default_value = "aln", help_heading = "Output")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,6 +303,8 @@ fn main() {
                             let res = kbo::map(ref_seq, &sbwt, &lcs, map_opts);
                             vcf_writer::write_vcf_contents(&mut stdout.lock(), &vcf_header, ref_seq, &res, ref_header).expect("Write contents to .vcf file");
                         });
+                } else {
+                    panic!("Unrecognized output format `--format {}``", out_format);
                 }
             });
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -426,9 +426,10 @@ fn main() {
                 let (sbwt, lcs) = kbo::index::build_sbwt_from_vecs(&contigs, &Some(sbwt_build_options.clone()));
 
                 if out_format == "aln" {
-                    // Concatenate the reference if it contains multiple contigs
-                    let ref_concat = ref_data.iter().map(|(_, contig)| contig.clone()).collect::<Vec<Vec<u8>>>();
-                    let res = kbo::map(&ref_concat.into_iter().flatten().collect::<Vec<u8>>(), &sbwt, &lcs, map_opts);
+                    let mut res: Vec<u8> = Vec::new();
+                    ref_data.iter().for_each(|(_, ref_seq)| {
+                        res.append(&mut kbo::map(ref_seq, &sbwt, &lcs, map_opts));
+                    });
                     let _ = writeln!(&mut stdout.lock(),
                                      ">{}\n{}", query_file, std::str::from_utf8(&res).expect("UTF-8"));
                 } else if out_format == "vcf" && *detailed {

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,7 +415,7 @@ fn main() {
                 if out_format == "aln" {
                     ref_data.iter().for_each(|ref_contig| {
                         indexes.iter().for_each(|((sbwt, lcs), contig_name, _)| {
-                            let res = kbo::map(ref_contig, &sbwt, &lcs, map_opts);
+                            let res = kbo::map(ref_contig, sbwt, lcs, map_opts);
                             let _ = writeln!(&mut stdout.lock(),
                                              ">{}\n{}", contig_name, std::str::from_utf8(&res).expect("UTF-8"));
                         });
@@ -429,8 +429,8 @@ fn main() {
 
                         ref_data.iter().for_each(|ref_contig| {
                             indexes.iter().for_each(|((sbwt, lcs), contig_name, _)| {
-                                let res = kbo::map(ref_contig, &sbwt, &lcs, map_opts);
-                                let _ = write_vcf(&mut stdout.lock(), &vcf_header, &ref_data.iter().flatten().collect::<Vec<&u8>>(), &res, &contig_name);
+                                let res = kbo::map(ref_contig, sbwt, lcs, map_opts);
+                                let _ = write_vcf(&mut stdout.lock(), &vcf_header, &ref_data.iter().flatten().collect::<Vec<&u8>>(), &res, contig_name);
                             });
                         });
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ fn write_vcf_header<W: Write>(f: &mut W,
 /// Write the contents of a .vcf file
 fn write_vcf<W: Write>(f: &mut W,
                        header: &vcf::Header,
-                       ref_seq: &[&u8],
+                       ref_seq: &[u8],
                        mapped_seq: &[u8],
                        contig_header: &str
 ) -> Result<(), std::io::Error> {
@@ -146,7 +146,7 @@ fn write_vcf<W: Write>(f: &mut W,
 
         let mapped_base = mapped_seq[mapped_pos];
 
-        let (genotype, alt_base) = if mapped_base == **ref_base {
+        let (genotype, alt_base) = if mapped_base == *ref_base {
             (String::from("0"), u8_to_base(mapped_base))
         } else if mapped_base == b'-' {
             // Only output changes that can be resolved
@@ -159,7 +159,7 @@ fn write_vcf<W: Write>(f: &mut W,
         };
 
         if variant {
-            let ref_allele = u8_to_base(**ref_base);
+            let ref_allele = u8_to_base(*ref_base);
             let genotypes = Genotypes::new(keys.clone(), vec![vec![Some(Value::String(genotype))]]);
             let alt_allele = vec![Allele::Bases(vec![alt_base])];
 
@@ -437,7 +437,7 @@ fn main() {
                         ref_data.iter().for_each(|ref_contig| {
                             indexes.iter().for_each(|((sbwt, lcs), contig_name, _)| {
                                 let res = kbo::map(ref_contig, sbwt, lcs, map_opts);
-                                let _ = write_vcf(&mut stdout.lock(), &vcf_header, &ref_data.iter().flatten().collect::<Vec<&u8>>(), &res, contig_name);
+                                let _ = write_vcf(&mut stdout.lock(), &vcf_header, ref_contig, &res, contig_name);
                             });
                         });
                 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -407,7 +407,7 @@ fn main() {
                     }
                 } else {
                     let contigs = read_fastx_file(query_file);
-                    let n_bases = ref_data.iter().map(|x| x.len()).reduce(|a, b| a + b).unwrap();
+                    let n_bases = contigs.iter().map(|x| x.len()).reduce(|a, b| a + b).unwrap();
                     let name = query_file.clone();
                     indexes.push((kbo::index::build_sbwt_from_vecs(&contigs, &Some(sbwt_build_options.clone())), name, n_bases));
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,42 +356,42 @@ fn main() {
 		},
 
         Some(cli::Commands::Map {
-			query_files,
-			ref_file,
+            query_files,
+            ref_file,
             detailed,
             out_format,
-			max_error_prob,
-			num_threads,
+            max_error_prob,
+            num_threads,
             kmer_size,
-			prefix_precalc,
-			dedup_batches,
-			mem_gb,
-			temp_dir,
-			verbose,
+            prefix_precalc,
+            dedup_batches,
+            mem_gb,
+            temp_dir,
+            verbose,
         }) => {
-			init_log(if *verbose { 2 } else { 1 });
+            init_log(if *verbose { 2 } else { 1 });
             let mut sbwt_build_options = kbo::index::BuildOpts::default();
-			// These are required for the subcommand to work correctly
-			sbwt_build_options.add_revcomp = true;
-			sbwt_build_options.build_select = true;
-			// These can be adjusted
-			sbwt_build_options.k = *kmer_size;
-			sbwt_build_options.num_threads = *num_threads;
-			sbwt_build_options.prefix_precalc = *prefix_precalc;
-			sbwt_build_options.dedup_batches = *dedup_batches;
-			sbwt_build_options.mem_gb = *mem_gb;
-			sbwt_build_options.temp_dir = temp_dir.clone();
+            // These are required for the subcommand to work correctly
+            sbwt_build_options.add_revcomp = true;
+            sbwt_build_options.build_select = true;
+            // These can be adjusted
+            sbwt_build_options.k = *kmer_size;
+            sbwt_build_options.num_threads = *num_threads;
+            sbwt_build_options.prefix_precalc = *prefix_precalc;
+            sbwt_build_options.dedup_batches = *dedup_batches;
+            sbwt_build_options.mem_gb = *mem_gb;
+            sbwt_build_options.temp_dir = temp_dir.clone();
 
-			let mut map_opts = kbo::MapOpts::default();
-			map_opts.max_error_prob = *max_error_prob;
+            let mut map_opts = kbo::MapOpts::default();
+            map_opts.max_error_prob = *max_error_prob;
 
-			rayon::ThreadPoolBuilder::new()
-				.num_threads(*num_threads)
-				.thread_name(|i| format!("rayon-thread-{}", i))
-				.build()
-				.unwrap();
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(*num_threads)
+                .thread_name(|i| format!("rayon-thread-{}", i))
+                .build()
+                .unwrap();
 
-			let ref_data = read_fastx_file(ref_file);
+            let ref_data = read_fastx_file(ref_file);
 
             let stdout = std::io::stdout();
 

--- a/src/vcf_writer.rs
+++ b/src/vcf_writer.rs
@@ -1,0 +1,135 @@
+// kbo-cli: Command-line interface to the kbo local aligner.
+//
+// Copyright 2024 Tommi Mäklin [tommi@maklin.fi].
+
+// Copyrights in this project are retained by contributors. No copyright assignment
+// is required to contribute to this project.
+
+// Except as otherwise noted (below and/or in individual files), this
+// project is licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE> or <http://www.apache.org/licenses/LICENSE-2.0> or
+// the MIT license, <LICENSE-MIT> or <http://opensource.org/licenses/MIT>,
+// at your option.
+//
+use std::io::Write;
+
+use chrono::offset::Local;
+use noodles_vcf::{
+    header::record::value::{map::Contig, Map},
+    header::record::value::Collection,
+    record::{
+        alternate_bases::Allele,
+        genotypes::{keys::key, sample::Value, Keys},
+        reference_bases::Base,
+        AlternateBases, Genotypes, Position,
+    },
+};
+
+/// [`u8`] representation used elsewhere to [`noodles_vcf::record::reference_bases::Base`]
+#[inline]
+fn u8_to_base(ref_base: u8) -> Base {
+    match ref_base {
+        b'A' => Base::A,
+        b'C' => Base::C,
+        b'G' => Base::G,
+        b'T' => Base::T,
+        _ => Base::N,
+    }
+}
+
+/// Write the header of a .vcf file
+pub fn write_vcf_header<W: Write>(f: &mut W,
+                              ref_name: &str,
+                              contig_info: &[(String, usize)],
+) -> Result<noodles_vcf::Header, std::io::Error> {
+    let mut writer = noodles_vcf::Writer::new(f);
+    let mut header_builder = noodles_vcf::Header::builder();
+    for (contig_header, length) in contig_info.iter() {
+        let record = Map::<Contig>::builder()
+            .set_length(*length)
+            .build();
+
+        let mut header_contents = contig_header.split_whitespace();
+        let contig_name = header_contents.next().expect("Contig name");
+        header_builder = header_builder.add_contig(
+            contig_name.parse().expect("Query contig name in header"),
+            record.expect("Record of type noodles_vcf::header::record::value::map::Contig"),
+        );
+
+    };
+    header_builder = header_builder.add_sample_name("unknown");
+    let mut header = header_builder.build();
+
+    let current_date = Local::now().format("%Y%m%d").to_string();
+    let vcf_date = Collection::Unstructured(vec![current_date]);
+    header.other_records_mut().insert("fileDate".parse().expect("Valid string"), vcf_date.clone());
+
+    let vcf_source = Collection::Unstructured(vec![format!("kbo-cli v{}", env!("CARGO_PKG_VERSION"))]);
+    header.other_records_mut().insert("source".parse().expect("Valid string"), vcf_source.clone());
+
+    let vcf_reference = Collection::Unstructured(vec![ref_name.to_string()]);
+    header.other_records_mut().insert("reference".parse().expect("Valid string"), vcf_reference.clone());
+
+    let vcf_phasing = Collection::Unstructured(vec!["none".to_string()]);
+    header.other_records_mut().insert("phasing".parse().expect("Valid string"), vcf_phasing.clone());
+
+    writer.write_header(&header)?;
+
+    Ok(header)
+}
+
+/// Write the contents of a .vcf file
+pub fn write_vcf_contents<W: Write>(f: &mut W,
+                       header: &noodles_vcf::Header,
+                       ref_seq: &[u8],
+                       mapped_seq: &[u8],
+                       contig_header: &str
+) -> Result<(), std::io::Error> {
+    let mut writer = noodles_vcf::Writer::new(f);
+
+    // Write each record (column)
+    let keys = Keys::try_from(vec![key::GENOTYPE]).unwrap();
+
+    for (mapped_pos, ref_base) in ref_seq.iter().enumerate() {
+        let alt_base: Base;
+        let mut variant = false;
+
+        let mapped_base = mapped_seq[mapped_pos];
+
+        let (genotype, alt_base) = if mapped_base == *ref_base {
+            (String::from("0"), u8_to_base(mapped_base))
+        } else if mapped_base == b'-' {
+            // Only output changes that can be resolved
+            variant = false;
+            (String::from("."), u8_to_base(b'-'))
+        } else {
+            variant = true;
+            alt_base = u8_to_base(mapped_base);
+            (mapped_base.to_string(), alt_base)
+        };
+
+        if variant {
+            let ref_allele = u8_to_base(*ref_base);
+            let genotypes = Genotypes::new(keys.clone(), vec![vec![Some(Value::String(genotype))]]);
+            let alt_allele = vec![Allele::Bases(vec![alt_base])];
+
+            let mut header_contents = contig_header.split_whitespace();
+            let contig_name = header_contents.next().expect("Contig name");
+
+            let record = noodles_vcf::Record::builder()
+                .set_chromosome(
+                    contig_name
+                        .parse()
+                        .expect("Invalid chromosome name"),
+                )
+                .set_position(Position::from(mapped_pos + 1))
+                .add_reference_base(ref_allele)
+                .set_alternate_bases(AlternateBases::from(alt_allele))
+                .set_genotypes(genotypes)
+                .build()
+                .expect("Could not construct record");
+            writer.write_record(header, &record)?;
+        }
+    }
+    Ok(())
+}

--- a/src/vcf_writer.rs
+++ b/src/vcf_writer.rs
@@ -105,7 +105,7 @@ pub fn write_vcf_contents<W: Write>(f: &mut W,
         } else {
             variant = true;
             alt_base = u8_to_base(mapped_base);
-            (mapped_base.to_string(), alt_base)
+            ("1".to_string(), alt_base)
         };
 
         if variant {


### PR DESCRIPTION
- Add `-f/--format` toggle to specify the output format (default .aln, can also write .vcf)

.vcf from kbo-cli have this format:
```
##fileformat=VCFv4.4
##contig=<ID=30224_1#305_1,length=4971108>
##fileDate=20250304
##source=kbo-cli v0.1.1
##reference=30224_1#305_1.fna
##phasing=none
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	unknown
30224_1#305_1	28660	.	C	T	.	.	.	GT	1
30224_1#305_1	87002	.	A	G	.	.	.	GT	1
30224_1#305_1	169420	.	G	A	.	.	.	GT	1
```

When writing .vcf, kbo-cli will always process and report results for the reference contigs separately. This is different from writing .aln, where the contigs are still processed separately but the results are concatenated.

Building the .vcf header and records is done using [noodles_vcf](https://docs.rs/noodles-vcf/latest/noodles_vcf/).

Caveats:
- .vcf files currently only contain SNPs.
- INDELs should be possible algorithmically but require some research.
- map does not handle SNPs that are very close to each other (<< _k_), this may be possible to resolve by traversing the SBWT whenever short gaps are encountered.
- Default options to map are not good if the reference is very fragmented, can get better results by changing `-k` and `--max-error-prob`.